### PR TITLE
Expose requests to get spending transaction for a box (by id)

### DIFF
--- a/lib-api/src/main/java/org/ergoplatform/appkit/BlockchainContext.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/BlockchainContext.java
@@ -3,6 +3,7 @@ package org.ergoplatform.appkit;
 import sigmastate.Values;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * This interface represent a specific context of blockchain for execution
@@ -67,5 +68,8 @@ public interface BlockchainContext {
 
     /** Get unspent boxes protected by given ergo tree template */
     List<InputBox> getUnspentBoxesForErgoTreeTemplate(ErgoTreeTemplate template);
+
+    Optional<InputBox> getBoxByIdFromExplorer(ErgoId boxId);
+
 }
 

--- a/lib-api/src/main/java/org/ergoplatform/appkit/InputBox.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/InputBox.java
@@ -3,6 +3,7 @@ package org.ergoplatform.appkit;
 import sigmastate.Values;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Interface of UTXO boxes which can be accessed in the blockchain node.
@@ -32,5 +33,7 @@ public interface InputBox {
     Values.ErgoTree getErgoTree();
 
     String toJson(boolean prettyPrint);
+
+    Optional<ErgoId> getSpentTransactionId();
 }
 

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ExplorerFacade.java
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ExplorerFacade.java
@@ -51,4 +51,17 @@ public class ExplorerFacade extends ApiFacade {
         });
     }
 
+    static public TransactionOutput transactionsBoxesIdGet(
+            Retrofit r, String boxId) throws ErgoClientException {
+        return execute(r, () -> {
+            Method method = TransactionsApi.class
+                    .getMethod("transactionsBoxesIdGet",
+                            String.class);
+            TransactionOutput res =
+                    RetrofitUtil.<TransactionOutput>invokeServiceMethod(r, method, new Object[]{boxId})
+                            .execute().body();
+            return res;
+        });
+    }
+
 }

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/InputBoxImpl.java
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/InputBoxImpl.java
@@ -9,18 +9,29 @@ import org.ergoplatform.restapi.client.JSON;
 import sigmastate.Values;
 
 import java.util.List;
+import java.util.Optional;
 
 public class InputBoxImpl implements InputBox {
     private final BlockchainContextImpl _ctx;
     private final ErgoId _id;
     private final ErgoBox _ergoBox;
     private final ErgoTransactionOutput _boxData;
+    private final Optional<ErgoId> _spentTxId;
 
     public InputBoxImpl(BlockchainContextImpl ctx, ErgoTransactionOutput boxData) {
         _ctx = ctx;
         _id = new ErgoId(JavaHelpers.decodeStringToBytes(boxData.getBoxId()));
         _ergoBox = ScalaBridge.isoErgoTransactionOutput().to(boxData);
         _boxData = boxData;
+        _spentTxId = Optional.empty();
+    }
+
+    public InputBoxImpl(BlockchainContextImpl ctx, ErgoTransactionOutput boxData, Optional<ErgoId> spentTxId) {
+        _ctx = ctx;
+        _id = new ErgoId(JavaHelpers.decodeStringToBytes(boxData.getBoxId()));
+        _ergoBox = ScalaBridge.isoErgoTransactionOutput().to(boxData);
+        _boxData = boxData;
+        _spentTxId = spentTxId;
     }
 
     public InputBoxImpl(BlockchainContextImpl ctx, ErgoBox ergoBox) {
@@ -28,6 +39,7 @@ public class InputBoxImpl implements InputBox {
         _ergoBox = ergoBox;
         _id = new ErgoId(ergoBox.id());
         _boxData = ScalaBridge.isoErgoTransactionOutput().from(ergoBox);
+        _spentTxId = Optional.empty();
     }
 
     @Override
@@ -70,5 +82,10 @@ public class InputBoxImpl implements InputBox {
     @Override
     public String toString() {
         return String.format("InputBox(%s, %s)", getId(), getValue());
+    }
+
+    @Override
+    public Optional<ErgoId> getSpentTransactionId() {
+        return _spentTxId;
     }
 }


### PR DESCRIPTION
Expose API requests needed to implement https://github.com/aslesarenko/ergo-tool/issues/31

Todo: 
- [x] get `transactions/boxes/id` and return `InputBox` (with added `spendingTxId`);
- [ ] get `transactions/id` and return [`FullTransaction`](http://github.com/aslesarenko/ergo-appkit/blob/00ce6c27b27631d6bf5aade621a05791096ab3bc/java-client-generated/src/main/java/org/ergoplatform/explorer/client/model/FullTransaction.java#L35-L35) as  ???; 